### PR TITLE
Fixing cloned object problem

### DIFF
--- a/web/static/js/napkin.js
+++ b/web/static/js/napkin.js
@@ -33,10 +33,15 @@
     duplicateActiveObject: function() {
       var canvas = this.canvas;
       var activeObj = canvas.getActiveObject();
-      var object = fabric.util.object.clone(activeObj);
-      object.set('top', object.top + 15);
-      object.set('left', object.left + 15);
-      canvas.add(object);
+      var copyData = activeObj.toObject();
+      fabric.util.enlivenObjects([copyData], function(objects) {
+        objects.forEach(function(o) {
+          o.set('top', o.top + 15);
+          o.set('left', o.left + 15);
+          canvas.add(o);
+        });
+        canvas.renderAll();
+      });
     },
 
     removeActiveObject: function() {


### PR DESCRIPTION
Resolves #13 

For some reason the fabricjs utility method for cloning objects was maintaining some kind of reference to the original object so changes to the clone would affect the original.  

I'm fixing this by serializing the object and deserializing into a completely new object. 
